### PR TITLE
Fix unhandled exception with non-ascii filenames

### DIFF
--- a/contrib/lastmp
+++ b/contrib/lastmp
@@ -49,7 +49,7 @@ class Song:
         try:
             return lastfm.repr(self.dict())
         except ValueError:
-            return self.file
+            return lastfm.marshaller.guess_enc(self.file, 'utf-8')
 
     def dict(self):
         d = {'time': time.gmtime(),


### PR DESCRIPTION
If a reported file doesn't have any tags, the file name is used for logging, but this file name is not properly decoded, so file names with non-ASCII characters make this program exit with a traceback.

This commit properly decodes the file name.
